### PR TITLE
Add poll progress bar color and vertical rendering

### DIFF
--- a/nodebb-plugin-markdown-modified/public/js/client.js
+++ b/nodebb-plugin-markdown-modified/public/js/client.js
@@ -266,7 +266,7 @@
 				parentNode.addClass('markdown-highlight');
 
 				// Default language if set in ACP
-				if (!Array.prototype.some.call(block.classList, (className) => className.startsWith('language-')) && config.markdown.defaultHighlightLanguage) {
+				if (!Array.prototype.some.call(block.classList, className => className.startsWith('language-')) && config.markdown.defaultHighlightLanguage) {
 					block.classList.add(`language-${config.markdown.defaultHighlightLanguage}`);
 				}
 
@@ -277,7 +277,8 @@
 					if (className.indexOf('language-') === 0) {
 						className = className.slice(9);
 					}
-					return config.markdown.highlightLinesLanguageList.includes(className) || config.markdown.highlightLinesLanguageList.includes(className);
+					return config.markdown.highlightLinesLanguageList.includes(className) ||
+						config.markdown.highlightLinesLanguageList.includes(className);
 				}).some(Boolean)) {
 					$(block).attr('data-lines', 1);
 					window.hljs.lineNumbersBlock(block);

--- a/nodebb-plugin-markdown-modified/websockets.js
+++ b/nodebb-plugin-markdown-modified/websockets.js
@@ -21,7 +21,7 @@ module.exports.checkbox = {
 			indices.push(match.index);
 		}
 
-		content = content.replace(checkboxRegex, function (match, idx) {
+		content = content.replace(checkboxRegex, (match, idx) => {
 			if (idx !== indices[data.index]) {
 				return match;
 			}

--- a/nodebb-plugin-poll-modified/lib/config.js
+++ b/nodebb-plugin-poll-modified/lib/config.js
@@ -28,6 +28,8 @@ const pluginId = pluginInfo.id.replace('nodebb-plugin-', '');
 			maxvotes: 1,
 			disallowVoteUpdate: 0,
 			end: 0,
+			horizontal: false,
+			color: '#ff0000',
 		},
 	};
 

--- a/nodebb-plugin-poll-modified/public/js/poll/creator.js
+++ b/nodebb-plugin-poll-modified/public/js/poll/creator.js
@@ -10,30 +10,17 @@
 
 		$(window).on('action:composer.loaded', function (ev, data) {
 			if ($.Redactor) {
-				if (
-					data.composerData.isMain &&
-					$.Redactor.opts.plugins.indexOf('poll') === -1
-				) {
+				if (data.composerData.isMain && $.Redactor.opts.plugins.indexOf('poll') === -1) {
 					$.Redactor.opts.plugins.push('poll');
-				} else if (
-					!data.composerData.isMain &&
-					$.Redactor.opts.plugins.indexOf('poll') !== -1
-				) {
-					$.Redactor.opts.plugins.splice(
-						$.Redactor.opts.plugins.indexOf('poll'),
-						1
-					);
+				} else if (!data.composerData.isMain && $.Redactor.opts.plugins.indexOf('poll') !== -1) {
+					$.Redactor.opts.plugins.splice($.Redactor.opts.plugins.indexOf('poll'), 1);
 				}
 			}
 		});
 	}
 
 	function initComposer() {
-		require(['composer', 'composer/formatting', 'composer/controls'], function (
-			composer,
-			formatting,
-			controls
-		) {
+		require(['composer', 'composer/formatting', 'composer/controls'], function (composer, formatting, controls) {
 			if (formatting && controls) {
 				formatting.addButtonDispatch('poll', function (textarea) {
 					composerBtnHandle(composer, textarea);
@@ -50,17 +37,11 @@
 
 					// require translator as such because it was undefined without it
 					require(['translator'], function (translator) {
-						translator.translate(
-							'[[poll:creator_title]]',
-							function (translated) {
-								var button = self.button.add('poll', translated);
-								self.button.setIcon(
-									button,
-									'<i class="fa fa-bar-chart-o"></i>'
-								);
-								self.button.addCallback(button, self.poll.onClick);
-							}
-						);
+						translator.translate('[[poll:creator_title]]', function (translated) {
+							var button = self.button.add('poll', translated);
+							self.button.setIcon(button, '<i class="fa fa-bar-chart-o"></i>');
+							self.button.addCallback(button, self.poll.onClick);
+						});
 					});
 				},
 				onClick: function () {
@@ -82,66 +63,59 @@
 	function composerBtnHandle(composer, textarea) {
 		require(['composer/controls', 'alerts'], function (controls, alerts) {
 			var post = composer.posts[composer.active];
-			if (
-				!post ||
-				!post.isMain ||
-				(isNaN(parseInt(post.cid, 10)) && isNaN(parseInt(post.pid, 10)))
-			) {
+			if (!post || !post.isMain || (isNaN(parseInt(post.cid, 10)) && isNaN(parseInt(post.pid, 10)))) {
 				return alerts.error('[[poll:error.not_main]]');
 			}
 			if (parseInt(post.cid, 10) === 0) {
 				return alerts.error('[[error:category-not-selected]]');
 			}
 
-			Poll.sockets.canCreate(
-				{ cid: post.cid, pid: post.pid },
-				function (err, canCreate) {
-					if (err) {
-						return alerts.error(err.message);
-					}
-					if (!canCreate) {
-						return alerts.error('[[error:no-privileges]]');
-					}
-
-					Poll.sockets.getConfig(null, function (err, config) {
-						if (err) {
-							console.error(err);
-						}
-
-						var poll = {};
-
-						// If there's already a poll in the post, serialize it for editing
-						if (Poll.serializer.canSerialize(textarea.value)) {
-							poll = Poll.serializer.serialize(textarea.value, config);
-
-							if (poll.settings.end === 0) {
-								delete poll.settings.end;
-							} else {
-								poll.settings.end = parseInt(poll.settings.end, 10);
-							}
-						}
-
-						Creator.show(poll, config, function (data) {
-							// Anything invalid will be discarded by the serializer
-							var markup = Poll.serializer.deserialize(data, config);
-
-							// Remove any existing poll markup
-							textarea.value = Poll.serializer.removeMarkup(textarea.value);
-
-							// Insert the poll markup at the bottom
-							if (textarea.value.charAt(textarea.value.length - 1) !== '\n') {
-								markup = '\n' + markup;
-							}
-
-							if ($.Redactor) {
-								textarea.redactor(textarea.value + '<p>' + markup + '</p>');
-							} else {
-								controls.insertIntoTextarea(textarea, markup);
-							}
-						});
-					});
+			Poll.sockets.canCreate({ cid: post.cid, pid: post.pid }, function (err, canCreate) {
+				if (err) {
+					return alerts.error(err.message);
 				}
-			);
+				if (!canCreate) {
+					return alerts.error('[[error:no-privileges]]');
+				}
+
+				Poll.sockets.getConfig(null, function (err, config) {
+					if (err) {
+						console.error(err);
+					}
+
+					var poll = {};
+
+					// If there's already a poll in the post, serialize it for editing
+					if (Poll.serializer.canSerialize(textarea.value)) {
+						poll = Poll.serializer.serialize(textarea.value, config);
+
+						if (poll.settings.end === 0) {
+							delete poll.settings.end;
+						} else {
+							poll.settings.end = parseInt(poll.settings.end, 10);
+						}
+					}
+
+					Creator.show(poll, config, function (data) {
+						// Anything invalid will be discarded by the serializer
+						var markup = Poll.serializer.deserialize(data, config);
+
+						// Remove any existing poll markup
+						textarea.value = Poll.serializer.removeMarkup(textarea.value);
+
+						// Insert the poll markup at the bottom
+						if (textarea.value.charAt(textarea.value.length - 1) !== '\n') {
+							markup = '\n' + markup;
+						}
+
+						if ($.Redactor) {
+							textarea.redactor(textarea.value + '<p>' + markup + '</p>');
+						} else {
+							controls.insertIntoTextarea(textarea, markup);
+						}
+					});
+				});
+			});
 		});
 	}
 
@@ -150,139 +124,116 @@
 			return Poll.alertError('Editing not implemented');
 		}
 
-		require([
-			'flatpickr',
-			'flatpickr.i10n',
-			'bootbox',
-			'dayjs',
-			'translator',
-		], function (flatpickr, flatpickrI10N, bootbox, dayjs, Translator) {
-			app.parseAndTranslate(
-				'poll/creator',
-				{ poll: poll, config: config, isRedactor: !!$.Redactor },
-				function (html) {
-					// Initialise modal
-					var modal = bootbox.dialog({
-						title: '[[poll:creator_title]]',
-						message: html,
-						className: 'poll-creator',
-						buttons: {
-							cancel: {
-								label: '[[modules:bootbox.cancel]]',
-								className: 'btn-default',
-								callback: function () {
-									return true;
-								},
-							},
-							save: {
-								label: '[[modules:bootbox.confirm]]',
-								className: 'btn-primary',
-								callback: function (e) {
-									clearErrors();
-									var form = $(e.currentTarget)
-										.parents('.bootbox')
-										.find('#pollCreator');
-									var obj = serializeObjectFromForm(form);
-
-									// Let's be nice and at least show an error if there are no options
-									obj.options.filter(function (obj) {
-										return obj.length;
-									});
-
-									if (obj.options.length === 0) {
-										return error('[[poll:error.no_options]]');
-									}
-
-									if (
-										obj.settings.end &&
-										!dayjs(new Date(obj.settings.end)).isValid()
-									) {
-										return error('[[poll:error.valid_date]]');
-									} else if (obj.settings.end) {
-										obj.settings.end = dayjs(
-											new Date(obj.settings.end)
-										).valueOf();
-									}
-
-									callback(obj);
-									return true;
-								},
+		require(['flatpickr', 'flatpickr.i10n', 'bootbox', 'dayjs', 'translator'], function (flatpickr, flatpickrI10N, bootbox, dayjs, Translator) {
+			app.parseAndTranslate('poll/creator', { poll: poll, config: config, isRedactor: !!$.Redactor }, function (html) {
+				// Initialise modal
+				var modal = bootbox.dialog({
+					title: '[[poll:creator_title]]',
+					message: html,
+					className: 'poll-creator',
+					buttons: {
+						cancel: {
+							label: '[[modules:bootbox.cancel]]',
+							className: 'btn-default',
+							callback: function () {
+								return true;
 							},
 						},
+						save: {
+							label: '[[modules:bootbox.confirm]]',
+							className: 'btn-primary',
+							callback: function (e) {
+								clearErrors();
+								var form = $(e.currentTarget).parents('.bootbox').find('#pollCreator');
+								var obj = serializeObjectFromForm(form);
+
+								// Let's be nice and at least show an error if there are no options
+								obj.options.filter(function (obj) {
+									return obj.length;
+								});
+
+								if (obj.options.length === 0) {
+									return error('[[poll:error.no_options]]');
+								}
+
+								if (obj.settings.end && !dayjs(new Date(obj.settings.end)).isValid()) {
+									return error('[[poll:error.valid_date]]');
+								} else if (obj.settings.end) {
+									obj.settings.end = dayjs(new Date(obj.settings.end)).valueOf();
+								}
+
+								callback(obj);
+								return true;
+							},
+						},
+					},
+				});
+
+				// Add option adder
+				modal
+					.find('#pollAddOption')
+					.off('click')
+					.on('click', function (e) {
+						var el = $(e.currentTarget);
+						var prevOption = el.prev();
+
+						if (config.limits.maxOptions <= el.prevAll('input').length) {
+							clearErrors();
+							require(['translator'], function (translator) {
+								translator.translate('[[poll:error.max_options]]', function (text) {
+									error(text.replace('%d', config.limits.maxOptions));
+								});
+							});
+							return false;
+						}
+
+						if (prevOption.val().length !== 0) {
+							prevOption.clone().val('').insertBefore(el).focus();
+						}
 					});
 
-					// Add option adder
-					modal
-						.find('#pollAddOption')
-						.off('click')
-						.on('click', function (e) {
-							var el = $(e.currentTarget);
-							var prevOption = el.prev();
+				// Add option remover
+				modal
+					.find('#pollRemoveOption')
+					.off('click')
+					.on('click', function (e) {
+						var el = $(e.currentTarget);
+						var AddOption = el.prev();
+						var prevOption = AddOption.prev();
 
-							if (config.limits.maxOptions <= el.prevAll('input').length) {
-								clearErrors();
-								require(['translator'], function (translator) {
-									translator.translate(
-										'[[poll:error.max_options]]',
-										function (text) {
-											error(text.replace('%d', config.limits.maxOptions));
-										}
-									);
+						if (el.prevAll('input').length <= 1) {
+							clearErrors();
+							require(['translator'], function (translator) {
+								translator.translate('[[poll:error.max_options]]', function (text) {
+									error(text.replace('%d', 1));
 								});
-								return false;
-							}
-
-							if (prevOption.val().length !== 0) {
-								prevOption.clone().val('').insertBefore(el).focus();
-							}
-						});
-
-					// Add option remover
-					modal
-						.find('#pollRemoveOption')
-						.off('click')
-						.on('click', function (e) {
-							var el = $(e.currentTarget);
-							var AddOption = el.prev();
-							var prevOption = AddOption.prev();
-
-							if (el.prevAll('input').length <= 1) {
-								clearErrors();
-								require(['translator'], function (translator) {
-									translator.translate(
-										'[[poll:error.max_options]]',
-										function (text) {
-											error(text.replace('%d', 1));
-										}
-									);
-								});
-								return false;
-							}
-							if (prevOption.prevAll('input').length !== 0) {
-								prevOption.remove();
-							}
-						});
-
-					var currentLocale = Translator.getLanguage();
-					var flatpickrInstance = flatpickr('.flatpickr', {
-						enableTime: true,
-						altFormat: 'F j, Y h:i K',
-						time_24hr: false,
-						wrap: true,
-						locale: getFlatpickrLocale(currentLocale, flatpickrI10N.default),
-						onOpen: function () {
-							modal.removeAttr('tabindex');
-						},
-						onClose: function () {
-							modal.attr('tabindex', -1);
-						},
+							});
+							return false;
+						}
+						if (prevOption.prevAll('input').length !== 0) {
+							prevOption.remove();
+						}
 					});
 
-					if (poll.settings && poll.settings.end) {
-						flatpickrInstance.setDate(poll.settings.end);
-					}
+				var currentLocale = Translator.getLanguage();
+				var flatpickrInstance = flatpickr('.flatpickr', {
+					enableTime: true,
+					altFormat: 'F j, Y h:i K',
+					time_24hr: false,
+					wrap: true,
+					locale: getFlatpickrLocale(currentLocale, flatpickrI10N.default),
+					onOpen: function () {
+						modal.removeAttr('tabindex');
+					},
+					onClose: function () {
+						modal.attr('tabindex', -1);
+					},
+				});
+
+				if (poll.settings && poll.settings.end) {
+					flatpickrInstance.setDate(poll.settings.end);
 				}
-			);
+			});
 		});
 	};
 
@@ -301,14 +252,16 @@
 
 	function serializeObjectFromForm(form) {
 		var obj = form.serializeObject();
+		console.log('Parsed form: ', obj);
 		var result = {
 			options: obj.options,
 			settings: {
 				title: obj['settings.title'],
 				maxvotes: obj['settings.maxvotes'],
-				disallowVoteUpdate:
-					obj['settings.disallowVoteUpdate'] === 'on' ? 'true' : 'false',
+				disallowVoteUpdate: obj['settings.disallowVoteUpdate'] === 'on' ? 'true' : 'false',
 				end: obj['settings.end'],
+				horizontal: obj.pollInputViewType === 'horizontal',
+				color: obj['poll.color'],
 			},
 		};
 

--- a/nodebb-plugin-poll-modified/public/js/poll/serializer.js
+++ b/nodebb-plugin-poll-modified/public/js/poll/serializer.js
@@ -38,6 +38,22 @@ module.exports = function (utils) {
 				return parseInt(value, 10);
 			},
 		},
+		horizontal: {
+			test: function (value) {
+				return /true|false/.test(value);
+			},
+			parse: function (value) {
+				return value === 'true' || value === true ? 1 : 0;
+			},
+		},
+		color: {
+			test: function (value) {
+				return /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(value);
+			},
+			parse: function (value) {
+				return value;
+			},
+		},
 	};
 
 	Serializer.canSerialize = function (post) {
@@ -70,6 +86,8 @@ module.exports = function (utils) {
 	};
 
 	Serializer.deserialize = function (poll, config) {
+		console.log('Deserializing function');
+		console.trace();
 		var options = deserializeOptions(poll.options, config);
 		var settings = deserializeSettings(poll.settings, config);
 
@@ -117,6 +135,7 @@ module.exports = function (utils) {
 	}
 
 	function serializeSettings(raw, config) {
+		console.log('Serializing settings', raw, config);
 		var settings = {};
 
 		Object.keys(config.defaults).forEach(function (key) {
@@ -135,18 +154,18 @@ module.exports = function (utils) {
 				}
 			}
 		}
-
+		console.log('Serialized: ', settings);
 		return settings;
 	}
 
 	function deserializeSettings(settings, config) {
+		console.log('Deserializing settings', settings, config);
 		var deserialized = '';
 
 		for (var k in settings) {
 			if (settings.hasOwnProperty(k) && config.defaults.hasOwnProperty(k)) {
 				var key = utils.stripHTMLTags(k).trim();
 				var value = utils.stripHTMLTags(settings[k]).trim();
-
 				if (key.length && value.length && settingsValidators.hasOwnProperty(key)) {
 					if (settingsValidators[key].test(value)) {
 						deserialized += ' ' + key + '="' + value + '"';
@@ -154,7 +173,7 @@ module.exports = function (utils) {
 				}
 			}
 		}
-
+		console.log('Deserialized: ', deserialized);
 		return deserialized;
 	}
 

--- a/nodebb-plugin-poll-modified/templates/poll/creator.tpl
+++ b/nodebb-plugin-poll-modified/templates/poll/creator.tpl
@@ -28,6 +28,12 @@
         
     </div>
 
+    <div class="mb-3">
+        <label class="form-label" for="poll.color">Poll color</label>
+        <input type="text" name="poll.color" id="poll.color" value="#ff0000"
+               placeholder="Color in hex format" class="form-control">
+    </div>
+
     <hr>
 
     <div class="mb-3">

--- a/nodebb-plugin-poll-modified/templates/poll/view.tpl
+++ b/nodebb-plugin-poll-modified/templates/poll/view.tpl
@@ -1,7 +1,8 @@
 <div class="poll-view" data-poll-id="{poll.info.pollId}">
-    <div class="card">
+    <div class="card" style="color: {poll.settings.color}">
         <div class="card-header">
             <h3 class="card-title">{poll.settings.title}</h3>
+            <h3 class="card-title">Horizontal: {poll.settings.horizontal}</h3>
             <div class="btn-group float-end hidden">
                 <a href="#" class="poll-button-edit">
                     <span class="fa fa-pencil"></span>

--- a/nodebb-plugin-poll-modified/templates/poll/view.tpl
+++ b/nodebb-plugin-poll-modified/templates/poll/view.tpl
@@ -2,7 +2,6 @@
     <div class="card" style="color: {poll.settings.color}">
         <div class="card-header">
             <h3 class="card-title">{poll.settings.title}</h3>
-            <h3 class="card-title">Horizontal: {poll.settings.horizontal}</h3>
             <div class="btn-group float-end hidden">
                 <a href="#" class="poll-button-edit">
                     <span class="fa fa-pencil"></span>

--- a/nodebb-plugin-poll-modified/templates/poll/view/results.tpl
+++ b/nodebb-plugin-poll-modified/templates/poll/view/results.tpl
@@ -7,9 +7,15 @@
         </a>
     </small>
     <div class="progress">
-        <div class="progress-bar poll-result-progressbar" role="progressbar" aria-valuenow="{poll.options.percentage}" aria-valuemin="0" aria-valuemax="100" style="width: {poll.options.percentage}%;">
+        <div id="my_progress_bar" class="progress-bar poll-result-progressbar" role="progressbar" aria-valuenow="{poll.options.percentage}" aria-valuemin="0" aria-valuemax="100" style="width: {poll.options.percentage}%;">
             <span><span class="percent">{poll.options.percentage}</span>%</span>
         </div>
     </div>
 </div>
 <!-- END poll.options -->
+
+<style>
+#my_progress_bar {
+    background-color: {poll.settings.color};
+}
+</style>

--- a/nodebb-plugin-poll-modified/templates/poll/view/results.tpl
+++ b/nodebb-plugin-poll-modified/templates/poll/view/results.tpl
@@ -1,21 +1,50 @@
 <!-- BEGIN poll.options -->
-<div class="poll-result" data-poll-option-id="{poll.options.id}">
-    <strong>{poll.options.title}</strong>
-    <small class="pull-right">
-        <a class="poll-result-votecount" href="#">
-            <span>{poll.options.voteCount}</span> [[poll:votes]]
-        </a>
-    </small>
-    <div class="progress">
-        <div id="my_progress_bar" class="progress-bar poll-result-progressbar" role="progressbar" aria-valuenow="{poll.options.percentage}" aria-valuemin="0" aria-valuemax="100" style="width: {poll.options.percentage}%;">
-            <span><span class="percent">{poll.options.percentage}</span>%</span>
-        </div>
-    </div>
-</div>
-<!-- END poll.options -->
-
 <style>
 #my_progress_bar {
     background-color: {poll.settings.color};
 }
 </style>
+<script>
+{
+    let horizontal = `    
+        <strong>{poll.options.title}</strong>
+        <small class="pull-right">
+            <a class="poll-result-votecount" href="#">
+                <span>{poll.options.voteCount}</span> [[poll:votes]]
+            </a>
+        </small>
+    <div class="progress">
+            <div id="my_progress_bar" class="progress-bar poll-result-progressbar" role="progressbar" aria-valuenow="{poll.options.percentage}" aria-valuemin="0" aria-valuemax="100" style="width: {poll.options.percentage}%;">
+                <span><span class="percent">{poll.options.percentage}</span>%</span>
+            </div>
+        </div>
+    `;
+
+    let vertical = `
+        <div style="display: flex; align-items: flex-end; margin-right: 20px; float: left;">
+            <div class="progress progress-bar-vertical" style="width: 20px; min-height: 100px; ">
+                <div id="my_progress_bar" class="progress-bar" style="width: 20px; height: {poll.options.percentage}%; position: relative; top: calc(100% - {poll.options.percentage}%);">
+                </div>
+            </div><br>
+            <strong>{poll.options.title}&nbsp</strong>
+            <small class="">
+                <a class="poll-result-votecount" href="#">
+                    <span>{poll.options.voteCount}</span> [[poll:votes]]
+                </a>
+            </small>
+        </div>
+    `;
+
+    if ({poll.settings.horizontal} == 0)
+        document.getElementById('poll-content-{poll.options.id}').innerHTML = vertical;
+    else 
+        document.getElementById('poll-content-{poll.options.id}').innerHTML = horizontal;
+}
+</script>
+
+<div class="poll-result" data-poll-option-id="{poll.options.id}">
+<div id="poll-content-{poll.options.id}"></div>
+
+</div>
+<!-- END poll.options -->
+


### PR DESCRIPTION
Resolves #19 #18 #9 #14 

This pull request adds 
- The ability to serialize and deserialize the color options and view type options for the poll rendering
- Regex parsing and validating the color and view type options
- The UI textbox for changing the color in the poll creator
- HTML template detection of which color and view type is used
- The ability to change the color of the poll progress bar HTML 
- The ability to change the display type of poll progress bar HTML
- Newly created vertical poll progress bar rendering code

This PR requires no additional dependencies, passes `npm run test`, but does not pass `npm run lint`, which is a potential future task.