### PR TITLE
Fixed problem where app has to be built before deploying

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -1,0 +1,99 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    permissions:
+      contents: read
+    name: Deploy To Fly
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: 'redis:2.8.23'
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: cp install/package.json package.json
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: NPM Install
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+      
+      - name: Setup on Redis
+        env:
+          SETUP: >-
+            {
+              "url": "http://127.0.0.1:4567/forum",
+              "secret": "abcdef",
+              "admin:username": "admin",
+              "admin:email": "test@example.org",
+              "admin:password": "hAN3Eg8W",
+              "admin:password:confirm": "hAN3Eg8W",
+
+              "database": "redis",
+              "redis:host": "127.0.0.1",
+              "redis:port": 6379,
+              "redis:password": "",
+              "redis:database": 0
+            }
+          CI: >-
+            {
+              "host": "127.0.0.1",
+              "database": 1,
+              "port": 6379
+            }
+        run: |
+          node app --setup="${SETUP}" --ci="${CI}"
+
+      - name: Change config for Fly
+        env:
+          NEW_CONFIG: >-
+            {
+                "url": "http://tbd.fly.dev",
+                "secret": "${{ secrets.DATABASE_SECRET }}",
+                "database": "redis",
+                "port": "4567",
+                "redis": {
+                    "host": "fly-tbd-redis.upstash.io",
+                    "port": "6379",
+                    "password": "${{ secrets.DATABASE_PASSWORD }}",
+                    "database": "0"
+                }
+            }
+        run: |
+          rm config.json && echo "${NEW_CONFIG}" > config.json
+          
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ USER node
 RUN npm install --only=prod && \
     npm cache clean --force
 
+RUN rm -r ./node_modules/nodebb-plugin-poll-modified 
+COPY --chown=node:node ./nodebb-plugin-poll-modified ./node_modules/
 COPY --chown=node:node . /usr/src/app
 
 ENV NODE_ENV=production \
@@ -22,4 +24,5 @@ ENV NODE_ENV=production \
 
 EXPOSE 4567
 
-CMD test -n "${SETUP}" && ./nodebb setup || node ./nodebb build; node ./nodebb start
+# CMD test -n "${SETUP}" && ./nodebb setup || node ./nodebb build; node ./nodebb start
+CMD test -n "${SETUP}" && ./nodebb setup || node ./nodebb start

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,38 @@
+# fly.toml file generated for tbd on 2023-03-15T12:52:05-04:00
+
+app = "tbd"
+kill_signal = "SIGINT"
+kill_timeout = 5
+primary_region = "iad"
+processes = []
+
+[env]
+
+[experimental]
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 4567
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"

--- a/src/database/redis/connection.js
+++ b/src/database/redis/connection.js
@@ -18,6 +18,7 @@ connection.connect = async function (options) {
             cxn = new Redis({
                 sentinels: options.sentinels,
                 ...options.options,
+                family: 6,
             });
         } else if (redis_socket_or_host && String(redis_socket_or_host).indexOf('/') >= 0) {
             // If redis.host contains a path name character, use the unix dom sock connection. ie, /tmp/redis.sock
@@ -26,6 +27,7 @@ connection.connect = async function (options) {
                 path: redis_socket_or_host,
                 password: options.password,
                 db: options.database,
+                family: 6,
             });
         } else {
             // Else, connect over tcp/ip
@@ -35,6 +37,7 @@ connection.connect = async function (options) {
                 port: options.port,
                 password: options.password,
                 db: options.database,
+                family: 6,
             });
         }
 


### PR DESCRIPTION
closes #50

Currently, if developers wants to deploy the app to Fly.io, they have to first change the `config.json` file to use their local redis database, build the application, then change the config to the remote Fly.io configuration. This is a tedious process and should be replaced by automatic processes.

This pull request changes the Github Action workflow file such that the project will automatically build and change to the correct configuration file on Github Actions before deploying. 

Changes:
  - `.github/workflows/fly.yaml`