### PR TITLE
Fixed correct workflow name for deployment

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Deploy App
 
 on:
   push:


### PR DESCRIPTION
Currently, the workflow that deploys to Fly.io has the name `Test`. Therefore, the name of the workflow does not truly reflect the actions being taken.

To fix this, this pull request fixes the first line of `.github/workflows/fly.yaml` file, namely, `name: Test` into `name: Deploy App`