### PR TITLE
Fix deployed app not able to create new post

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -52,7 +52,7 @@ jobs:
         env:
           SETUP: >-
             {
-              "url": "http://127.0.0.1:4567/forum",
+              "url": "http://127.0.0.1:4567",
               "secret": "abcdef",
               "admin:username": "admin",
               "admin:email": "test@example.org",


### PR DESCRIPTION
closes #53

Currently, when a user tries to create a new post on the deployed application, the app crashes and nothing happens. Below is a screenshot of the button not working. 

The expected behavior is a post-drafting page popping up and allowing me to participate in this forum.

Looking into the page inspector, there are  `failed to load resource` errors.

![image](https://user-images.githubusercontent.com/33432158/227346736-408f3689-0298-4b0a-aa57-85e272157147.png)

This pull request fixes this bug by modifying the setup URL in `.github/workflows/fly.yaml` file. Specifcally, `"url": "http://127.0.0.1:4567/forum",` on line 55 is changed to `"url": "http://127.0.0.1:4567",`.
